### PR TITLE
Minor UX fixes

### DIFF
--- a/scraper_app/parsers/zonaprop.py
+++ b/scraper_app/parsers/zonaprop.py
@@ -13,7 +13,7 @@ class ZonapropParser(BaseParser):
     price_regex = 'span.firstPrice'
     description_regex = 'div.postingCardDescription'
     location_regex = 'span.postingCardLocation'
-    _base_url = 'https://www.zonaprop.com.ar/'
+    _base_url = 'https://www.zonaprop.com.ar'
 
     def extract_data(self) -> Set[Posting]:
         '''Extracting data and returning list of postings'''

--- a/telegram_app/services.py
+++ b/telegram_app/services.py
@@ -14,12 +14,14 @@ class TelegramService:
 
     def format_posting_to_message(self, posting: Posting) -> str:
         '''Formats the object into a Telegram message.'''
-        msg = '<b>{}</b>\n<i>{}</i> - <i>{}</i>\n\n{}\n\n{}'.format(
+        msg = '<a href="{}"><b>{}</b></a>\n{}<i>{}</i>\n{}<i>{}</i>\n\n{}'.format(
+            posting.url,
             posting.title,
+            u'\U0001F4B0',
             posting.price,
+            u'\U0001F4CD',
             posting.location,
             posting.description,
-            posting.url,
         )
 
         return msg

--- a/telegram_app/services.py
+++ b/telegram_app/services.py
@@ -15,7 +15,7 @@ class TelegramService:
     def format_posting_to_message(self, posting: Posting) -> str:
         '''Formats the object into a Telegram message.'''
         msg = '<a href="{}"><b>{}</b></a>\n{}<i>{}</i>\n{}<i>{}</i>\n\n{}'.format(
-            posting.url,
+            posting.url.split('#')[0],
             posting.title,
             u'\U0001F4B0',
             posting.price,


### PR DESCRIPTION
- En la URL de ZonaProp había una '/' de más al final que hacía que desde telegram diera error al clickear el link para redirigir después.

- Se agregaron íconos para los mensajes en telegram

- Se corrigió un error de parseo en la URL de mercadolibre. Había un '#' que rompía la forma en la que se ve el mensaje en Telegram y no era necesario. Lo estoy modificando en la parte donde se muestra, pero se podría modificar para que esa corrección se haga antes de guardar la URL directamente.
